### PR TITLE
Add `filesBlacklist` to avoid preloading certain files

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ const objectAssign = require('object-assign');
 const defaultOptions = {
   rel: 'preload',
   as: 'script',
-  include: 'asyncChunks'
+  include: 'asyncChunks',
+  fileBlacklist: [/\.map/]
 };
 
 class PreloadPlugin {
@@ -68,7 +69,9 @@ class PreloadPlugin {
               })
               .map(chunk => chunk.files);
         }
-        extractedChunks.forEach(entry => {
+        extractedChunks.filter(entry => {
+          return this.options.fileBlacklist.every(regex => regex.test(entry) === false)
+        }).forEach(entry => {
           if (options.rel === 'preload') {
             filesToInclude+= `<link rel="${options.rel}" href="${entry}" as="${options.as}">\n`;
           } else {

--- a/test/spec.js
+++ b/test/spec.js
@@ -164,3 +164,32 @@ describe('PreloadPlugin filters chunks', function() {
     compiler.outputFileSystem = new MemoryFileSystem();
   });
 });
+
+describe('filtering unwanted files', function() {
+  it('does not include map files to be preloaded', function(done) {
+    const compiler = webpack({
+      entry: {
+        js: path.join(__dirname, 'fixtures', 'file.js')
+      },
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'bundle.js',
+        chunkFilename: 'chunk.[chunkhash].js',
+        publicPath: '/',
+      },
+      devtool: 'cheap-source-map',
+      plugins: [
+        new HtmlWebpackPlugin(),
+        new PreloadPlugin()
+      ]
+    }, function(err, result) {
+      expect(err).toBeFalsy();
+      expect(JSON.stringify(result.compilation.errors)).toBe('[]');
+      const html = result.compilation.assets['index.html'].source();
+      expect(html).toContain('<link rel="preload" href="chunk.');
+      expect(html).not.toContain('.map"');
+      done();
+    });
+    compiler.outputFileSystem = new MemoryFileSystem();
+  });
+});


### PR DESCRIPTION
For example, sourcemaps should not be preloaded.

This is configurable via the `filesBlacklist` option. This would be a
breaking change, but you could easily avoid that by making the array
empty and just advising people on how to add it in the docs.